### PR TITLE
[Feature/pagination] ページネーション機能の実装

### DIFF
--- a/src/Hooks/useBreakpoint.ts
+++ b/src/Hooks/useBreakpoint.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect } from "react";
+
+const breakpoints = {
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+};
+
+type Breakpoint = 'sm' | 'md' | 'lg' | 'xl' | 'default';
+
+export const useBreakpoint = (): Breakpoint => {
+    const [breakpoint, setBreakpoint] = useState<Breakpoint>('default');
+
+    useEffect(() => {
+        const handleResize = () => {
+            const width = window.innerWidth;
+            if (width >= breakpoints.xl) {
+                setBreakpoint('xl');
+            } else if (width >= breakpoints.lg) {
+                setBreakpoint('lg');
+            } else if (width >= breakpoints.md) {
+                setBreakpoint('md');
+            } else if (width >= breakpoints.sm) {
+                setBreakpoint('sm');
+            } else {
+                setBreakpoint('default');
+            }
+        };
+        handleResize();
+        window.addEventListener('resize', handleResize);
+        
+        return () => window.removeEventListener('resize', handleResize);
+    },[])
+
+    return breakpoint;
+}

--- a/src/components/Hooks/usePagination.ts
+++ b/src/components/Hooks/usePagination.ts
@@ -1,0 +1,61 @@
+import { useMemo } from "react";
+
+export const DOTS = '...';
+
+interface UsePaginationProps {
+    totalPages: number;
+    siblingCount?: number;  // 現在のページの前後に表示するページ個数
+    currentPage: number;
+}
+
+const range = (start: number, end: number) => {
+    const length = end - start + 1;
+    return Array.from({length}, (_, index) => index + start);
+}
+
+export const usePagination = ({totalPages, siblingCount = 1, currentPage}: UsePaginationProps) => {
+    const paginationRange = useMemo(() => {
+        // ページネーション枠の個数（例: 1(先頭) + 1(末尾) + 1(現在) + 2*siblingCount + 2(DOTS) = 7）
+        const totalPageNumbers = siblingCount + 5;
+        const firstPageIndex = 1;
+        const lastPageIndex = totalPages;
+
+        // 表示するページ番号の数より総ページ数が少ない場合
+        if(totalPageNumbers >= totalPages) {
+            return range(firstPageIndex, lastPageIndex);
+        }
+
+        // それ以外の場合の準備処理
+        // 兄弟ページの先頭/末尾の番号を計算
+        const leftSiblingIndex = Math.max(currentPage - siblingCount, 1);
+        const rightSiblingIndex = Math.min(currentPage + siblingCount, totalPages);
+        // DOTSが必要かの判断
+        const shouldShowLeftDots = leftSiblingIndex > 2;
+        const shouldShowrightDots = rightSiblingIndex < totalPages -2;
+
+
+        // 右側のDOTSだけ表示する場合
+        if(!shouldShowLeftDots && shouldShowrightDots) {
+            // DOTSより左側の個数
+            const leftItemCount = 3 + siblingCount * 2;
+            const leftRange = range(firstPageIndex, leftItemCount);
+            return [...leftRange, DOTS, lastPageIndex];
+        }
+
+        // 左側のDOTSだけ表示する場合
+        if(shouldShowLeftDots && !shouldShowrightDots) {
+            // DOTSより右側の個数
+            const rightItemCount = 3 + siblingCount * 2;
+            const rightRange = range(lastPageIndex - rightItemCount +1, lastPageIndex);
+            return [firstPageIndex, DOTS, ...rightRange];
+        }
+
+        // 左右にDOTSを表示する場合
+        if(shouldShowLeftDots && shouldShowrightDots) {
+            const middleRange = range(leftSiblingIndex, rightSiblingIndex);
+            return [firstPageIndex, DOTS, ...middleRange, DOTS, lastPageIndex];
+        }
+    },[totalPages, siblingCount, currentPage]);
+
+    return paginationRange;
+}

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,69 @@
+import { usePagination, DOTS } from "./Hooks/usePagination";
+
+interface PaginationProps {
+    currentPage: number;
+    totalPages: number;
+    siblingCount?: number;
+    onPageChange: (page: number) => void;
+}
+
+const Pagination = ({currentPage, totalPages, siblingCount = 1, onPageChange}: PaginationProps) => {
+    const paginationRange = usePagination({totalPages, siblingCount, currentPage});
+    if (totalPages <= 1 || !paginationRange) return null;
+
+    const onNext = () => {
+        onPageChange(currentPage + 1);
+    }
+    const onPrevious = () => {
+        onPageChange(currentPage - 1);
+    }
+    const lastPage = paginationRange[paginationRange.length - 1];
+
+    return (
+        <ul className="flex list-none items-center justify-center space-x-1">
+            <li>
+                <button
+                    type='button'
+                    onClick={onPrevious}
+                    disabled={currentPage === 1}
+                    className="px-3 py-2 leading-tight text-gray-500 bg-white border border-gray-300 rounded-l-lg hover:bg-gray-100 hover:text-gray-700 disabled:opacity-50"
+                >
+                    前へ
+                </button>
+            </li>
+            {paginationRange.map((pageNumber, index) => {
+                const key = pageNumber === DOTS? `DOTS-${index}` : `page-${pageNumber}`;
+                if(pageNumber === DOTS) {
+                    return <li key={key} className="px-3 py-2 text-gray-400">&#8230;</li>;
+                }
+                return (
+                    <li key={key}>
+                        <button
+                            type='button'
+                            onClick={() => onPageChange(pageNumber as number)}
+                            className={`px-3 py-2 leading-tight border ${
+                                currentPage === pageNumber
+                                    ? 'bg-blue-500 text-white border-blue-500'
+                                    : 'text-gray-500 bg-white border-gray-300 hover:bg-gray-100 hover:text-gray-700'
+                            }`}
+                        >
+                            {pageNumber}
+                        </button>
+                    </li>
+                );
+            })}
+            <li>
+                <button
+                    type='button'
+                    onClick={onNext}
+                    disabled={currentPage === lastPage}
+                    className="px-3 py-2 leading-tight text-gray-500 bg-white border border-gray-300 rounded-r-lg hover:bg-gray-100 hover:text-gray-700 disabled:opacity-50"
+                >
+                    次へ
+                </button>
+            </li>
+        </ul>
+    );
+}
+
+export default Pagination;

--- a/src/features/cart/Hooks/useCart.ts
+++ b/src/features/cart/Hooks/useCart.ts
@@ -5,7 +5,6 @@ import type { CartItem } from "../../../types";
 
 // GET /cart- カート情報の取得
 const fetchCart = async (): Promise<CartItem[]> => {
-    console.log(`[fetchCart]`);
     const response = await apiClient.get<CartItem[]>('/cart');
     return response.data;
 }
@@ -20,7 +19,6 @@ export const useCart = (user: User | null) => {
 
 // POST /cart - カートに商品を追加
 const addToCart = async ({productId, quantity=1}: {productId: number, quantity?: number}): Promise<CartItem> => {
-    console.log(`[addToCart] productId: ${productId} quantity: ${quantity}`);
     const response = await apiClient.post('/cart', {productId, quantity});
     return response.data;
 }

--- a/src/features/products/Hooks/useProducts.ts
+++ b/src/features/products/Hooks/useProducts.ts
@@ -2,14 +2,23 @@ import { useQuery } from "@tanstack/react-query";
 import apiClient from "../../../lib/axios";
 import type { Product } from "../../../types";
 
+interface ProductsApiResponse {
+    products: Product[];
+    totalPages: number;
+    currentPage: number;
+    totalProducts: number;
+}
+
 interface ProductFilters {
     search?: string;
     category?: string;
     sortBy?: string;
     sortOrder?: 'asc' | 'desc';
+    page?: number;
+    pageSize?: number;
 }
 
-const fetchProducts = async ({queryKey}: {queryKey: (string | ProductFilters)[]}): Promise<Product[]> => {
+const fetchProducts = async ({queryKey}: {queryKey: (string | ProductFilters)[]}): Promise<ProductsApiResponse> => {
     const [_key, filters] = queryKey;
 
     const params = new URLSearchParams();
@@ -18,6 +27,8 @@ const fetchProducts = async ({queryKey}: {queryKey: (string | ProductFilters)[]}
         if(filters.category) params.append('category', filters.category);
         if(filters.sortBy) params.append('sortBy', filters.sortBy);
         if(filters.sortOrder) params.append('sortOrder', filters.sortOrder);
+        if(filters.page) params.append('page', filters.page.toString());
+        if(filters.pageSize) params.append('pageSize', filters.pageSize.toString());
     }
     
     const {data} = await apiClient.get(`/products?${params.toString()}`)


### PR DESCRIPTION
【概要】
商品一覧ページのパフォーマンス向上のためページネーション機能を実装
これによりアイテム数が増加しても表示速度を維持可能

【実装内容】
■usePagination.ts [新規作成]
ページネーションに表示する値（"…"含む）を格納する配列を計算するカスタムフック
useMemoを使用しtotalPages, siblingCount, currentPageが変更されたときのみ再計算を行うように実装
■Pagination.tsx [新規作成]
usePaginationフックを利用し、ページネーションのUIを描画するコンポーネント
<li>のkeyにはページの追加削除など発生してもずれの発生しないユニークなkeyを設定
■ProductList.tsx [修正]
現在のページ番号を管理するためのuseStateを追加
useBreakpoint.tsフックを利用し1ページに表示するアイテム数を計算する処理を追加
useProductsフックにpageとpageSizeを渡すように修正
フィルター条件が変更された際、または1ページに表示するアイテム数(breakpoint)に変更があった際に、ページ番号を1にリセットするuseEffectを追加
リストの下部にページネーションコンポーネントを配置
画面サイズにより表示するアイテム数を調整（XLの際の表示を追加）
APIからの返却値にも変更があり（totalPages、currentPage、totalProductsが追加された）、受け取りの形を変更したことによりproductsを直接受け取れなくなったため、productsを利用していた既存処理には受け取ったオブジェクト内のproductsを渡すように修正
■useProducts.ts [修正]
APIからの返却値にも変更があったため（totalPages、currentPage、totalProductsが追加された）、受け取りの形を変更
商品データ取得時のクエリパラメータにpageとpageSizeを追加
■useBreakpoint.ts [新規追加]
現在の画面サイズを計算するカスタムフック
画面サイズの変更も検知できるようイベントリスナーも登録
アンマウント時にはイベントリスナーの解除も行う

【確認方法】
商品一覧ページを開きます。
ページ下部にページネーションが表示されていることを確認してください。
ページ番号や「次へ」「前へ」ボタンをクリックし、表示される商品が正しく切り替わることを確認してください。
（現在のsiblingCount=1の場合）現在ページの前後にページがある場合はそのページ番号が表示されていることを確認してください。
現在ページと1ページに3つ以上のページが挟まる場合は"…"が1ページの右に表示されることを確認してください。
現在ページと1ページに2つのページが挟まる場合は"…"が表示されないことを確認してください。
現在ページと最終ページに3つ以上のページが挟まる場合は"…"が最終ページの左に表示されることを確認してください。
現在ページと最終ページに2つのページが挟まる場合は"…"が表示されないことを確認してください。
検索やソートを行った際に、ページ番号が1に戻ることを確認してください。

【スクリーンショット】
![3page](https://github.com/user-attachments/assets/a44013ee-fc6c-4e34-aa35-64ab2bda76ae)
![11page](https://github.com/user-attachments/assets/8e55445d-a1b7-42ce-8d07-9230b01e6505)
