### PR TITLE
[refactor] ページリセットの実行場所の変更

### DIFF
--- a/src/constants/pagination.ts
+++ b/src/constants/pagination.ts
@@ -1,0 +1,1 @@
+export const FIRST_PAGE = 1;

--- a/src/features/products/Hooks/useProductFilters.ts
+++ b/src/features/products/Hooks/useProductFilters.ts
@@ -1,4 +1,9 @@
 import React, { useState } from "react";
+import { FIRST_PAGE } from "../../../constants/pagination";
+
+interface useProductFiltersProps {
+    setPage: (pageNumber: number) => void;
+}
 
 interface ProductFiltersReturn {
     // 状態の値
@@ -18,7 +23,7 @@ interface ProductFiltersReturn {
     handleSortOrderChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
 }
 
-export const useProductFilters = (): ProductFiltersReturn => {
+export const useProductFilters = ({setPage}: useProductFiltersProps): ProductFiltersReturn => {
     // 検索・フィルタリング用のローカルステート
     const [searchTerm, setSearchTerm] = useState('');
     const [appliedFilters, setAppliedFilters] = useState({
@@ -34,6 +39,7 @@ export const useProductFilters = (): ProductFiltersReturn => {
             ...prev,
             search: searchTerm,
         }));
+        setPage(FIRST_PAGE);
     };
     const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         setSearchTerm(event.target.value);
@@ -46,18 +52,21 @@ export const useProductFilters = (): ProductFiltersReturn => {
             ...prev,
             category: event.target.value,
         }));
+        setPage(FIRST_PAGE);
     }
     const handleSortByChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
         setAppliedFilters(prev => ({
             ...prev,
             sortBy: event.target.value,
         }));
+        setPage(FIRST_PAGE);
     }
     const handleSortOrderChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
         setAppliedFilters(prev => ({
             ...prev,
             sortOrder: event.target.value as 'asc' | 'desc',
         }));
+        setPage(FIRST_PAGE);
     };
     
     return {

--- a/src/features/products/ProductList.tsx
+++ b/src/features/products/ProductList.tsx
@@ -10,10 +10,13 @@ import { useProductFilters } from "./Hooks/useProductFilters";
 import { useProducts } from "./Hooks/useProducts";
 import { useBreakpoint } from "../../Hooks/useBreakpoint";
 import Pagination from "../../components/Pagination";
+import { FIRST_PAGE } from "../../constants/pagination";
 
-const FIRST_PAGE = 1
 
 const ProductList = () => {
+    const [page, setPage] = useState(FIRST_PAGE);
+    const breakpoint = useBreakpoint();
+
     const {
         searchTerm,
         appliedFilters,
@@ -23,10 +26,7 @@ const ProductList = () => {
         handleCategoryChange,
         handleSortByChange,
         handleSortOrderChange,
-    } = useProductFilters();
-    
-    const [page, setPage] = useState(FIRST_PAGE);
-    const breakpoint = useBreakpoint();
+    } = useProductFilters({setPage});
 
     const pageSize = useMemo(() => {
         switch (breakpoint) {
@@ -70,7 +70,7 @@ const ProductList = () => {
     // フィルター実行時・ブレイクポイント変更時にはページ番号を1に戻す
     useEffect(() => {
         setPage(FIRST_PAGE);
-    },[appliedFilters,breakpoint]);
+    },[breakpoint]);
 
     const handleRetry = () => {
         refetch();


### PR DESCRIPTION
【概要】
パフォーマンス向上の為、ページのリセット処理を移動
useEffectを利用しappliedFiltersを監視する設計だと、
1. appliedFiltersを変更したことによるAPIとのFetch
2. pageを変更したことによるAPIとのFetch
の計2回の商品取得Fetchが行われてしまう
これを1度にまとめる修正を行った

【修正内容】
■ProductList.tsx [修正]
useEffectの依存配列からフィルターのクエリパラメータであるappliedFiltersを削除
useProductFiltersにpageのセッター(setPage)をPropsで渡すように修正
（appliedFiltersを設定する箇所で同時にpageの設定も行えるようにするため）
■useProductFilters.ts [修正]
受け取ったpageのセッターを利用しappliedFiltersを設定した際はpageもFIRST_PAGE(1)に変更するように修正
■constants/pagination.ts [新規作成]
先頭ページの定数を定義するため新規作成

【懸念事項】
子コンポーネント(useProductFilters)に親コンポーネント(ProductList)の状態を変更するセッターを受け渡しているため、親子の結合が強くなってしまった
また、子から親の状態を変更するという依存性の逆転が起こってしまっているのが懸念点である