### PR TITLE
[refactor] (useProducts)queryKeyの型をタプル型へ変更

### DIFF
--- a/src/features/products/Hooks/useProducts.ts
+++ b/src/features/products/Hooks/useProducts.ts
@@ -21,7 +21,7 @@ interface ProductFilters {
 const fetchProducts = async ({
   queryKey,
 }: {
-  queryKey: (string | ProductFilters)[];
+  queryKey: [string, ProductFilters];
 }): Promise<ProductsApiResponse> => {
   const [_key, filters] = queryKey;
 


### PR DESCRIPTION
【概要】
コードの安定性を高めるため、汎用的な配列型からより厳密なタプル型に変更を行った

【修正内容】
汎用的に定義していた (string | ProductFilters)[] から、
その後の処理とも合致した [string, ProductFilters] に変更