### PR TITLE
[refactor] エラーメッセージの出力方法の修正

### DIFF
--- a/src/features/cart/CartItemRow.tsx
+++ b/src/features/cart/CartItemRow.tsx
@@ -19,8 +19,13 @@ const CartItemRow = ({ item }: CartItemProps) => {
     updateQuantity(
       { cartItemId: item.id, quantity: item.quantity + 1 },
       {
-        onError: (error: Error) =>
-          toast.error(error.message || '数量の更新に失敗しました。'),
+        onError: (error) => {
+          console.error('数量の増加更新に失敗しました。', error);
+          const errorMessage = error.response?.data?.message
+            ? error.response.data.message
+            : '数量の増加更新に失敗しました。';
+          toast.error(errorMessage);
+        },
       },
     );
   };
@@ -29,8 +34,13 @@ const CartItemRow = ({ item }: CartItemProps) => {
       updateQuantity(
         { cartItemId: item.id, quantity: item.quantity - 1 },
         {
-          onError: (error: Error) =>
-            toast.error(error.message || '数量の更新に失敗しました。'),
+          onError: (error) => {
+            console.error('数量の減少更新に失敗しました。', error);
+            const errorMessage = error.response?.data?.message
+              ? error.response.data.message
+              : '数量の減少更新に失敗しました。';
+            toast.error(errorMessage);
+          },
         },
       );
     } else {

--- a/src/features/cart/CartPage.tsx
+++ b/src/features/cart/CartPage.tsx
@@ -4,6 +4,7 @@ import type { CartItem } from '../../types';
 import toast from 'react-hot-toast';
 import CartItemRow from './CartItemRow';
 import { useAuth } from '../auth/AuthContext';
+import { AxiosError } from 'axios';
 
 export const CartPage = () => {
   const { user } = useAuth();
@@ -18,7 +19,12 @@ export const CartPage = () => {
   const handleClearCart = () => {
     clearCart(undefined, {
       onSuccess: () => toast.success('カートを空にしました。'),
-      onError: (error: Error) => toast.error(error.message),
+      onError: (error) => {
+        console.error('カートのクリアに失敗:', error);
+        const errorMessage =
+          error.response?.data?.message || 'カートのクリアに失敗しました。';
+        toast.error(errorMessage);
+      },
     });
   };
 
@@ -28,8 +34,8 @@ export const CartPage = () => {
 
   if (isError) {
     const errorMessage =
-      cartError instanceof Error
-        ? cartError.message
+      cartError instanceof AxiosError && cartError.response?.data?.message
+        ? cartError.response.data.message
         : '不明なエラーが発生しました。';
     return (
       <div className="text-center py-10 text-red-600">

--- a/src/features/cart/Hooks/useAddToCartToast.tsx
+++ b/src/features/cart/Hooks/useAddToCartToast.tsx
@@ -46,7 +46,12 @@ export const useAddToCartHandler = (): UseAddToCartHandlerReturn => {
       await toast.promise(promise, {
         loading: 'カートに追加中...',
         success: <b>{`${product.title}をカートに追加しました！`}</b>,
-        error: (err) => <b>{err || 'カートへの追加に失敗しました。'}</b>,
+        error: (error) => {
+          const errorMessage = error.response?.data?.message
+            ? error.response.data.message
+            : 'カートへの追加に失敗しました。';
+          return <b>{errorMessage}</b>;
+        },
       });
     } catch (error) {
       console.error(

--- a/src/features/cart/Hooks/useCart.ts
+++ b/src/features/cart/Hooks/useCart.ts
@@ -2,6 +2,8 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import type { User } from 'firebase/auth';
 import apiClient from '../../../lib/axios';
 import type { CartItem } from '../../../types';
+import { AxiosError } from 'axios';
+import type { ApiErrorData } from '../../../types/apiErrorData';
 
 // GET /cart- カート情報の取得
 const fetchCart = async (): Promise<CartItem[]> => {
@@ -10,7 +12,7 @@ const fetchCart = async (): Promise<CartItem[]> => {
 };
 
 export const useCart = (user: User | null) => {
-  return useQuery({
+  return useQuery<CartItem[], AxiosError<ApiErrorData>>({
     queryKey: ['cart'],
     queryFn: fetchCart,
     enabled: !!user,
@@ -31,7 +33,11 @@ const addToCart = async ({
 
 export const useAddToCart = () => {
   const queryClient = useQueryClient();
-  return useMutation({
+  return useMutation<
+    CartItem,
+    AxiosError<ApiErrorData>,
+    { productId: number; quantity?: number }
+  >({
     mutationFn: addToCart,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['cart'] });
@@ -53,7 +59,11 @@ const updateItemQuantity = async ({
 
 export const useUpdateItemQuantity = () => {
   const queryClient = useQueryClient();
-  return useMutation({
+  return useMutation<
+    CartItem,
+    AxiosError<ApiErrorData>,
+    { cartItemId: number; quantity: number }
+  >({
     mutationFn: updateItemQuantity,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['cart'] });
@@ -68,7 +78,7 @@ const removeItemFromCart = async (cartItemId: number) => {
 
 export const useRemoveItemFromCart = () => {
   const queryClient = useQueryClient();
-  return useMutation({
+  return useMutation<void, AxiosError<ApiErrorData>, number>({
     mutationFn: removeItemFromCart,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['cart'] });
@@ -83,7 +93,7 @@ const clearCart = async () => {
 
 export const useClearCart = () => {
   const queryClient = useQueryClient();
-  return useMutation({
+  return useMutation<void, AxiosError<ApiErrorData>, void>({
     mutationFn: clearCart,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['cart'] });

--- a/src/features/orders/Hooks/useOrder.ts
+++ b/src/features/orders/Hooks/useOrder.ts
@@ -1,6 +1,8 @@
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
 import apiClient from '../../../lib/axios';
 import type { Order } from '../../../types';
+import { AxiosError } from 'axios';
+import type { ApiErrorData } from '../../../types/apiErrorData';
 
 const fetchOrder = async (): Promise<Order[]> => {
   const response = await apiClient.get('/orders');
@@ -8,7 +10,10 @@ const fetchOrder = async (): Promise<Order[]> => {
 };
 
 export const useOrders = () => {
-  return useQuery({ queryKey: ['orders'], queryFn: fetchOrder });
+  return useQuery<Order[], AxiosError<ApiErrorData>>({
+    queryKey: ['orders'],
+    queryFn: fetchOrder,
+  });
 };
 
 const createOrder = async (): Promise<Order> => {
@@ -18,7 +23,7 @@ const createOrder = async (): Promise<Order> => {
 
 export const useCreateOrder = () => {
   const queryClient = useQueryClient();
-  return useMutation({
+  return useMutation<Order, AxiosError<ApiErrorData>, void>({
     mutationFn: createOrder,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['orders'] });

--- a/src/features/orders/OrderHistoryPage.tsx
+++ b/src/features/orders/OrderHistoryPage.tsx
@@ -1,8 +1,9 @@
 import { Link } from 'react-router-dom';
 import { useOrders } from './Hooks/useOrder';
+import { AxiosError } from 'axios';
 
 const OrderHistoryPage = () => {
-  const { data: orders, isLoading, isError } = useOrders();
+  const { data: orders, isLoading, isError, error } = useOrders();
 
   if (isLoading) {
     return (
@@ -10,11 +11,11 @@ const OrderHistoryPage = () => {
     );
   }
   if (isError) {
-    return (
-      <div className="text-center py-10 text-red-600">
-        注文履歴の読み込みに失敗しました。
-      </div>
-    );
+    const errorMessage =
+      error instanceof AxiosError && error.response?.data?.message
+        ? error.response.data.message
+        : '注文履歴の取得に失敗しました。';
+    return <div className="text-center py-10 text-red-600">{errorMessage}</div>;
   }
 
   return (

--- a/src/features/products/Hooks/useProducts.ts
+++ b/src/features/products/Hooks/useProducts.ts
@@ -1,6 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 import apiClient from '../../../lib/axios';
 import type { Product } from '../../../types';
+import { AxiosError } from 'axios';
+import type { ApiErrorData } from '../../../types/apiErrorData';
 
 interface ProductsApiResponse {
   products: Product[];
@@ -21,7 +23,7 @@ interface ProductFilters {
 const fetchProducts = async ({
   queryKey,
 }: {
-  queryKey: (string | ProductFilters)[];
+  queryKey: [string, ProductFilters];
 }): Promise<ProductsApiResponse> => {
   const [_key, filters] = queryKey;
 
@@ -41,7 +43,12 @@ const fetchProducts = async ({
 };
 
 export const useProducts = (filters: ProductFilters) => {
-  return useQuery({
+  return useQuery<
+    ProductsApiResponse,
+    AxiosError<ApiErrorData>,
+    ProductsApiResponse,
+    [string, ProductFilters]
+  >({
     queryKey: ['products', filters],
     queryFn: fetchProducts,
   });
@@ -53,7 +60,7 @@ const fetchProductById = async (productId: string): Promise<Product> => {
 };
 
 export const useProduct = (productId: string | undefined) => {
-  return useQuery({
+  return useQuery<Product, AxiosError<ApiErrorData>>({
     queryKey: ['product', productId],
     queryFn: () => fetchProductById(productId!),
     enabled: !!productId,

--- a/src/features/products/ProductDetailPage.tsx
+++ b/src/features/products/ProductDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useParams, Link } from 'react-router-dom';
 import AddToCartButton from '../cart/AddToCartButton';
 import { useProduct } from './Hooks/useProducts';
+import { AxiosError } from 'axios';
 
 export default function ProductDetailPage() {
   const { productId } = useParams<{ productId: string }>();
@@ -10,9 +11,13 @@ export default function ProductDetailPage() {
     return <div className="text-2xl text-center">ローディング中...</div>;
   }
   if (isError) {
+    const errorMessage =
+      error instanceof AxiosError && error.response?.data?.message
+        ? error.response.data.message
+        : '商品情報の読み込みに失敗しました。';
     return (
       <div className="text-2xl text-center text-red-700">
-        <p>エラー: {error.message || '商品情報の読み込みに失敗しました。'}</p>
+        <p>エラー: {errorMessage}</p>
         <Link to="/">商品一覧へ戻る</Link>
       </div>
     );

--- a/src/features/products/ProductList.tsx
+++ b/src/features/products/ProductList.tsx
@@ -11,6 +11,7 @@ import { useProducts } from './Hooks/useProducts';
 import { useBreakpoint } from '../../Hooks/useBreakpoint';
 import Pagination from '../../components/Pagination';
 import { FIRST_PAGE } from '../../constants/pagination';
+import { AxiosError } from 'axios';
 
 const ProductList = () => {
   const [page, setPage] = useState(FIRST_PAGE);
@@ -124,7 +125,11 @@ const ProductList = () => {
 
       {isError && (
         <ErrorDisplay
-          message={error instanceof Error ? error.message : '不明なエラーです'}
+          message={
+            error instanceof AxiosError && error.response?.data?.message
+              ? error.response.data.message
+              : '不明なエラーです'
+          }
           onRetry={handleRetry}
         />
       )}

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -6,4 +6,6 @@ if (!stripePublicKey) {
   throw new Error('Stripe public key is not set');
 }
 
-export const stripePromise = loadStripe(stripePublicKey);
+export const stripePromise = loadStripe(stripePublicKey, {
+  locale: 'ja',
+});

--- a/src/types/apiErrorData.ts
+++ b/src/types/apiErrorData.ts
@@ -1,0 +1,4 @@
+// エラーメッセージ出力用のプロパティ定義
+export interface ApiErrorData {
+  message: string;
+}


### PR DESCRIPTION
【概要】
エラー発生時の画面へのエラー出力メッセージが開発者向けのメッセージだったため、
ユーザー向けの文章を出力するように修正を行った
※Auth関係のコンポーネントは今後tanStackを利用した構造にリファクタリング予定のため、今回の修正ではAuth関係のコンポーネントは対象外とした

【修正内容】
<修正内容>
tanStackがスローした開発者向けのエラーメッセージを出力していた箇所を、
API側から送られてきたエラーメッセージが格納されているAxiosErrorのresponse.data.messageを出力するように修正
<対象ファイル> CartItemRow.tsx CartPage.tsx OrderHistoryPage.tsx ProductDetailPage.tsx ProductList.tsx

<修正内容>
エラーメッセージを出力するコンポーネントにおいて、コードエディタが受け取ったerrorオブジェクトにresponse.data.messageが存在することを推察できないでいたため、errorの型を推察可能なAxiosError<ApiErrorData>型に型指定を行った
<対象ファイル> useAddToCartToast.tsx useCart.ts useOrder.ts useProducts.ts

<修正内容>
stripeの出力エラーメッセージがデフォルトの英語のままとなっていたため、日本語出力されるように修正
<対象ファイル> stripe.ts

<追加内容>
errorの型にAxiosErrorを指定してもなおresponse.data.messageまでの推察を行えなかったため、推察可能な型を追加するための型定義を行った
<対象ファイル> apiErrorData.ts