### PR TITLE
[fix] TT-8 ドル表記も混在していたため、日本円表記に統一

### DIFF
--- a/src/features/cart/CartItemRow.tsx
+++ b/src/features/cart/CartItemRow.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { useRemoveItemFromCart, useUpdateItemQuantity } from './Hooks/useCart';
 import type { CartItem } from '../../types';
+import { formatPriceJpy } from '../../utils/formatters';
 
 interface CartItemProps {
   item: CartItem;
@@ -77,7 +78,7 @@ const CartItemRow = ({ item }: CartItemProps) => {
           </Link>
         </h3>
         <p className="text-sm text-gray-500 mb-2">
-          単価: ${item.product.price.toFixed(2)}
+          単価: ¥ {formatPriceJpy(item.product.price)}
         </p>
       </div>
       <div className="flex items-center my-2 sm:my-0 sm:mx-6">
@@ -108,7 +109,7 @@ const CartItemRow = ({ item }: CartItemProps) => {
         </button>
       </div>
       <p className="font-semibold text-gray-800 w-24 text-center sm:text-right my-2 sm:my-0">
-        ${(item.product.price * item.quantity).toFixed(2)}
+        ¥ {formatPriceJpy(item.product.price * item.quantity)}
       </p>
       <button
         onClick={() => handleRemoveItem()}

--- a/src/features/cart/CartPage.tsx
+++ b/src/features/cart/CartPage.tsx
@@ -94,7 +94,7 @@ export const CartPage = () => {
       <div className="mt-8 p-4 bg-gray-50 rounded-lg shadow">
         <div className="flex justify-between items-center mb-4">
           <h3 className="text-xl font-semibold text-gray-800">合計金額:</h3>
-          <p className="text-2xl font-bold text-green-600">{`$ ${totalPrice}`}</p>
+          <p className="text-2xl font-bold text-green-600">{`¥ ${totalPrice}`}</p>
         </div>
         <div className="flex flex-col sm:flex-row justify-end space-y-2 sm:space-y-0 sm:space-x-3">
           <button

--- a/src/features/cart/Hooks/useCartTotalPrice.ts
+++ b/src/features/cart/Hooks/useCartTotalPrice.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useAuth } from '../../auth/AuthContext';
 import { useCart } from './useCart';
+import { formatPriceJpy } from '../../../utils/formatters';
 
 interface UseCartTotalPriceReturn {
   totalPrice: string | null;
@@ -20,7 +21,7 @@ export const UseCartTotalPrice = (): UseCartTotalPriceReturn => {
       (sum, item) => sum + item.product.price * item.quantity,
       0,
     );
-    return sum.toFixed(2);
+    return formatPriceJpy(sum);
   }, [cartItems, isLoading, isError]);
 
   return {

--- a/src/features/checkout/CheckoutPage.tsx
+++ b/src/features/checkout/CheckoutPage.tsx
@@ -152,11 +152,11 @@ const CheckoutPage = () => {
           </h2>
           <div className="flex justify-between items-center border-b pb-3 mb-3">
             <p className="text-gray-600">小計</p>
-            <p className="font-medium text-gray-800">${totalPrice}</p>
+            <p className="font-medium text-gray-800">¥ {totalPrice}</p>
           </div>
           <div className="flex justify-between items-center pt-3 mt-3 border-t border-gray-200">
             <p className="text-lg font-bold text-gray-800">合計</p>
-            <p className="text-2xl font-bold text-green-600">${totalPrice}</p>
+            <p className="text-2xl font-bold text-green-600">¥ {totalPrice}</p>
           </div>
         </div>
       </div>

--- a/src/features/orders/OrderHistoryPage.tsx
+++ b/src/features/orders/OrderHistoryPage.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useOrders } from './Hooks/useOrder';
 import { AxiosError } from 'axios';
+import { formatPriceJpy } from '../../utils/formatters';
 
 const OrderHistoryPage = () => {
   const { data: orders, isLoading, isError, error } = useOrders();
@@ -40,7 +41,7 @@ const OrderHistoryPage = () => {
                 <div>
                   <p className="text-sm text-gray-500">合計金額</p>
                   <p className="font-bold text-xl text-gray-800">
-                    {order.totalPrice.toLocaleString()}
+                    ¥ {formatPriceJpy(order.totalPrice)}
                   </p>
                 </div>
                 <div className="text-sm text-gray-500">
@@ -63,7 +64,7 @@ const OrderHistoryPage = () => {
                         {item.product.title}
                       </Link>
                       <p className="text-sm text-gray-600">
-                        ¥{item.price.toLocaleString()} x {item.quantity}点
+                        ¥ {formatPriceJpy(item.price)} x {item.quantity}点
                       </p>
                     </div>
                   </li>

--- a/src/features/products/ProductDetailPage.tsx
+++ b/src/features/products/ProductDetailPage.tsx
@@ -2,6 +2,7 @@ import { useParams, Link } from 'react-router-dom';
 import AddToCartButton from '../cart/AddToCartButton';
 import { useProduct } from './Hooks/useProducts';
 import { AxiosError } from 'axios';
+import { formatPriceJpy } from '../../utils/formatters';
 
 export default function ProductDetailPage() {
   const { productId } = useParams<{ productId: string }>();
@@ -70,7 +71,7 @@ export default function ProductDetailPage() {
               </span>
             </div>
             <p className="text-3xl font-semibold text-green-600 mb-6">
-              価格: {product.price.toFixed(2)}
+              価格: ¥ {formatPriceJpy(product.price)}
             </p>
             <h2 className="text-lg font-semibold text-gray-700 mb-2">
               商品説明

--- a/src/features/products/ProductList.tsx
+++ b/src/features/products/ProductList.tsx
@@ -12,6 +12,7 @@ import { useBreakpoint } from '../../Hooks/useBreakpoint';
 import Pagination from '../../components/Pagination';
 import { FIRST_PAGE } from '../../constants/pagination';
 import { AxiosError } from 'axios';
+import { formatPriceJpy } from '../../utils/formatters';
 
 const ProductList = () => {
   const [page, setPage] = useState(FIRST_PAGE);
@@ -167,7 +168,7 @@ const ProductList = () => {
                 カテゴリ: {product.category}
               </p>
               <p className="text-xl font-bold text-gray-900 mt-auto mb-3">
-                価格: ${product.price.toFixed(2)}
+                価格: ¥ {formatPriceJpy(product.price)}
               </p>
               <AddToCartButton product={product} />
             </div>

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,0 +1,36 @@
+// src/utils/formatters.ts
+
+/**
+ * 数値を日本円の形式（カンマ区切り、小数点なし）にフォーマットします。
+ * @param value フォーマットする数値
+ * @returns フォーマットされた文字列
+ */
+
+export const formatPriceJpy = (value: number): string => {
+  // NaNやInfinityの場合のエラーハンドリング
+  if (isNaN(value) || !isFinite(value)) {
+    return 'N/A';
+  }
+  return new Intl.NumberFormat('ja-JP', {
+    style: 'decimal',
+    maximumFractionDigits: 0,
+  }).format(value);
+};
+
+/**
+ * 米ドルの表示形式（小数点以下2桁、カンマ区切り）にフォーマットします。
+ * 必要であれば、style: 'currency', currency: 'USD' に変更することも可能。
+ * @param value フォーマットする数値
+ * @returns フォーマットされた文字列
+ */
+
+export const formatPriceUsd = (value: number): string => {
+  if (isNaN(value) || !isFinite(value)) {
+    return 'N/A';
+  }
+  return new Intl.NumberFormat('en-US', {
+    style: 'decimal',
+    minimumFractionDigits: 2, // 常に小数点以下2桁を表示
+    maximumFractionDigits: 2, // 小数点以下2桁に制限
+  }).format(value);
+};


### PR DESCRIPTION
### 【チケット番号】
Closes TT-8

### 【概要】
以下のようなドル表記も散見されたため、円表記に統一を行った
- 小数点第2位の表示
- 金額の先頭に`$`表記
- 3桁ごとのカンマ区切りなし

### 【修正内容】
- 以下のフォーマットで出力するヘルパー関数(`formatters.ts`)を作成した
  - 少数以下を表示しない
  - 3桁ごとのカンマ区切り
- 従来の金額を表示していた箇所を、上記のヘルパー関数を使用した形に置き換えた
- 金額先頭の`$`記号を`¥`記号に置き換えた